### PR TITLE
circRNA testing gvf file updated

### DIFF
--- a/test/files/circ_rna.gvf
+++ b/test/files/circ_rna.gvf
@@ -1,5 +1,5 @@
 ##fileformat=VCFv4.2
-##mopepgen_version=0.0.1
+##mopepgen_version=0.3.1
 ##parser=parseCIRCexplorer
 ##reference_index=/hot/users/czhu/private-moPepGen/private-moPepGen-py/test/files/index
 ##genome_fasta=
@@ -12,8 +12,8 @@
 ##INFO=<ID=OFFSET,Number=+,Type=Integer,Description="Offsets of fragments (exons or introns)">
 ##INFO=<ID=LENGTH,Number=+,Type=Integer,Description="Lengths of fragments (exons or introns)">
 ##INFO=<ID=INTRON,Number=+,Type=Integer,Description="Indices of fragments that are introns">
-##INFO=<ID=TRANSCRIPT,Number=1,Type=String,Description="Transcript ID associated with this circRNA">
 ##POS=<Description="Gene coordinate of circRNA start">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-ENSG00000128408.9	0	CIRC-ENST00000614167.2-E1-E2	.	.	.	.	OFFSET=0,323;LENGTH=323,82;INTRON=;TRANSCRIPT=ENST00000614167.2;GENE_SYMBOL=RIBC2
-ENSG00000099949.21	0	CIRC-ENST00000642151.1-E1-E2	.	.	.	.	OFFSET=0,98;LENGTH=78,42;INTRON=;TRANSCRIPT=ENST00000642151.1;GENE_SYMBOL=LZTR1
+ENSG00000128408.9	0	CIRC-ENST00000614167.2-E1-E2	.	.	.	.	OFFSET=0,323;LENGTH=323,82;INTRON=;TRANSCRIPT_ID=ENST00000614167.2;GENE_SYMBOL=RIBC2;GENOMIC_POSITION=chr22:0
+ENSG00000099949.21	0	CIRC-ENST00000642151.1-E1-E2	.	.	.	.	OFFSET=0,98;LENGTH=78,42;INTRON=;TRANSCRIPT_ID=ENST00000642151.1;GENE_SYMBOL=LZTR1;GENOMIC_POSITION=chr22:4980
+ENSG00000099949.21	78	CI-ENST00000642151.1-I1	.	.	.	.	OFFSET=0;LENGTH=20;INTRON=0;TRANSCRIPT_ID=ENST00000642151.1;GENE_SYMBOL=LZTR1;GENOMIC_POSITION=chr22:5058


### PR DESCRIPTION
In our recent update of moPepGen we changed the GVF file for circRNA so the attribute name for transcript ID is changed from `TRANSCRIPT` to `TRNASCRIPT_ID` to be consistent with other GVF files. So the testing data needs to be updated in this pipeline.

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] All test cases have passed.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #
