### PR TITLE
fixed filterFasta that it will not run if it is set to false

### DIFF
--- a/config/methods.config
+++ b/config/methods.config
@@ -99,8 +99,8 @@ methods {
                 throw new Exception("Required option `variant_fasta` not set.")
             }
         }
-        params.filter_fasta_variant = params.containsKey('filterFasta') && params['filterFasta'].containsKey('variant_peptides')
-        params.filter_fasta_noncoding = params.containsKey('filterFasta') && params['filterFasta'].containsKey('noncoding_peptides')
+        params.filter_fasta_variant = params.containsKey('filterFasta') && (params['filterFasta'] in Map) && params['filterFasta'].containsKey('variant_peptides')
+        params.filter_fasta_noncoding = params.containsKey('filterFasta') && (params['filterFasta'] in Map) && params['filterFasta'].containsKey('noncoding_peptides')
         if (params.filter_fasta_noncoding && params.noncoding_peptides == '_NO_FILE') {
             throw new Exception('`noncoding_peptides` is not specified.')
         }


### PR DESCRIPTION
A little fix so `filterFasta` can be turned off easily. This is helpful in the metapipeline so if an expression table is not given, filterFasta won't run. 

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] All test cases have passed.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
