### PR TITLE
fix (summarizeFasta): parameter namespace fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
       - [callVariant](#callvariant)
       - [filterFasta](#filterfasta)
       - [splitFasta](#splitfasta)
+      - [summarizeFasta](#summarizefasta)
       - [decoyFasta](#decoyfasta)
   - [Outputs](#outputs)
   - [License](#license)
@@ -169,6 +170,14 @@ Filter fasta can run separately for variant and noncoding peptide FASTA, so this
 | `group_source` | no | Group sources. E.g., PointMutation:gSNP,sSNV INDEL:gINDEL,sINDEL (default: None) |
 | `max_source_groups` | no | Maximal number of different source groups to be separate intoindividual database FASTA files. Defaults to 1 (default: 1) |
 | `additional_split` | no | For peptides that were not already split into FASTAs up tomax_source_groups, those involving the following source will be splitinto additional FASTAs with decreasing priority (default: None) |
+
+#### summarizeFasta
+
+| Field name | Required | Description |
+| ---------- | -------- | ----------- |
+| `order_source` | no | Order of sources, separate by comma. E.g., SNP,SNV,Fusion (default: None) |
+| `cleavage_rule` | no | Enzymatic cleavage rule. (default: trypsin) |
+| `invalid_protein_as_noncoding` | no | Treat any transcript that the protein sequence is invalid (contains the * symbol) as noncoding. (default: False) |
 
 #### decoyFasta
 

--- a/modules/summarize_fasta.nf
+++ b/modules/summarize_fasta.nf
@@ -40,7 +40,7 @@ process summarize_fasta {
     script:
     output_summary = "${variant_fasta.baseName}_summary.txt"
     noncoding_arg = noncoding_peptides.name == '_NO_FILE' ? '' : "--noncoding-peptides ${noncoding_peptides}"
-    extra_args = generate_args(params, 'splitFasta', ARGS, FLAGS)
+    extra_args = generate_args(params, 'summarizeFasta', ARGS, FLAGS)
     """
     set -euo pipefail
 


### PR DESCRIPTION
The parameters for `summarizeFasta` was previously set to `filterFasta` by mistake. Fixed now.

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] All test cases have passed.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #38 
