### PR TITLE
fix (summarize_fasta): --ignore-missing-source added

### DIFF
--- a/modules/common.nf
+++ b/modules/common.nf
@@ -17,7 +17,7 @@ def generate_args(Map par, String namespace, Map args, Map flags) {
         if(it in args.keySet()) {
             res += " ${args[it]} ${par[namespace][it]}"
         } else if (it in flags.keySet() && par[namespace][it] == true) {
-            res += " ${args[it]}"
+            res += " ${flags[it]}"
         }
     }
     return res

--- a/modules/split_fasta.nf
+++ b/modules/split_fasta.nf
@@ -9,7 +9,7 @@ ARGS = [
 ]
 
 FLAGS = [
-    'invalid-protein-as-noncoding': '--invalid-protein-as-noncoding'
+    'invalid_protein_as_noncoding': '--invalid-protein-as-noncoding'
 ]
 
 def get_args_and_flags() {

--- a/modules/summarize_fasta.nf
+++ b/modules/summarize_fasta.nf
@@ -7,7 +7,8 @@ ARGS = [
 ]
 
 FLAGS = [
-    'invalid_protein_as_noncoding': '--invalid-protein-as-noncoding'
+    'invalid_protein_as_noncoding': '--invalid-protein-as-noncoding',
+    'ignore_missing_source': '--ignore-missing-source'
 ]
 
 def get_args_and_flags() {

--- a/test/test-integration-entrypoint-fasta/test.config
+++ b/test/test-integration-entrypoint-fasta/test.config
@@ -39,6 +39,10 @@ params {
         order_source = 'gSNP,gINDEL,Fusion'
         max_source_groups = 2
     }
+
+    summarizeFasta {
+        ignore_missing_source = true
+    }
 }
 
 methods.setup()


### PR DESCRIPTION
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] All test cases have passed.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #45 
