### PR TITLE
Update moPepGen to 0.7.1

### DIFF
--- a/config/default.config
+++ b/config/default.config
@@ -5,7 +5,7 @@ params {
     max_memory = SysHelper.getAvailMemory()
     ucla_cds = true
 
-    mopepgen_version = '0.6.2'
+    mopepgen_version = '0.7.1'
     docker_image_moPepGen = "blcdsdockerregistry/mopepgen:${params.mopepgen_version}"
     noncoding_peptides = '_NO_FILE'
     split_fasta = true

--- a/modules/call_variant.nf
+++ b/modules/call_variant.nf
@@ -23,6 +23,8 @@ process call_variant {
 
     container params.docker_image_moPepGen
 
+    containerOptions "--shm-size=10.24gb"
+
     publishDir params.final_output_dir,
         mode: 'copy',
         pattern: "*.fasta"


### PR DESCRIPTION
## Description

moPepGen version updated to 0.7.1. The option `--shm-size=10.24gb` is also added to `callVariant` process, required by `ray`.

Closes #66 

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] All test cases have passed.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
