### PR TITLE
noncoding peptides not passed  to mergeFasta

### DIFF
--- a/modules/process_database_merge.nf
+++ b/modules/process_database_merge.nf
@@ -21,9 +21,9 @@ workflow process_database_merge {
     main:
     // mergeFasta
     if (params.noncoding_peptides == '_NO_FILE') {
-        ich_noncoding_peptides = Channel.fromPath(params.noncoding_peptides)
+        ich_noncoding_peptides = Channel.fromList()
     } else {
-        ich_noncoding_peptides = Channel.fromList()    
+        ich_noncoding_peptides = Channel.fromPath(params.noncoding_peptides)
     }
     merge_fasta(variant_fasta.mix(ich_noncoding_peptides).collect())
 


### PR DESCRIPTION
Made a silly mistake..

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] All test cases have passed.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #82 
