### PR TITLE
Arguments added to callVairant

### DIFF
--- a/modules/call_variant.nf
+++ b/modules/call_variant.nf
@@ -3,6 +3,10 @@ include { generate_args } from "${moduleDir}/common"
 
 ARGS = [
     'max_variants_per_node': '--max-variants-per-node',
+    'additional_variants_per_misc': '--additional-variants-per-misc',
+    'min_nodes_to_collapse': '--min-nodes-to-collapse',
+    'naa_to_collapse': '--naa-to-collapse',
+    'verbose_level': '--verbose-level',
     'cleavage_rule': '--cleavage-rule',
     'miscleavage': '--miscleavage',
     'min_mw': '--min-mw',

--- a/test/test-integration-entrypoint-gvf/test.config
+++ b/test/test-integration-entrypoint-gvf/test.config
@@ -28,6 +28,10 @@ params {
         min_mw = 500
         min_length = 7
         max_length = 25
+        max_variants_per_node = 7
+        additional_variants_per_misc = 2
+        min_nodes_to_collapse = 30
+        naa_to_collapse = 5
     }
 
     filterFasta {


### PR DESCRIPTION
Some arguments were not supported in the pipeline which were added to moPepGen after the module was written. The new added arguments are:

- --additional-variants-per-misc'
- --min-nodes-to-collapse
- --naa-to-collapse
- --verbose-level

Closes #84

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] All test cases have passed.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

