### PR TITLE
fix file name collision of VEP files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Change to group input VEP files by source.
 - Fix issue when `novel_orf_peptide` and `alt_translation_peptide` are not specified.
+- Fix file name collision of VEP files.
 
 ## 1.0.0 - 2024/04/10
 

--- a/modules/parse_SourceVariant_workflow.nf
+++ b/modules/parse_SourceVariant_workflow.nf
@@ -5,6 +5,7 @@ include { parse_Arriba } from './parse_Arriba'
 include { parse_REDItools } from './parse_REDItools'
 include { parse_CIRCexplorer } from './parse_CIRCexplorer'
 include { parse_rMATS } from './parse_rMATS'
+include { resolve_conflictVEPFileName } from './resolve_conflictVEPFileName'
 
 /**
 * Workflow to call all moPepGen parsers
@@ -66,7 +67,9 @@ workflow parse_SourceVariant_workflow {
         return [source, se, a5ss, a3ss, mxe, ri]
     }
 
-    ich_vep = ich_branched.vep.groupTuple(by:0)
+    resolve_conflictVEPFileName(ich_branched.vep)
+
+    ich_vep = resolve_conflictVEPFileName.out[0].groupTuple(by:0)
 
     parse_VEP(ich_vep, file(params.index_dir))
     parse_STARFusion(ich_branched.star_fusion, file(params.index_dir))

--- a/modules/resolve_conflictVEPFileName.nf
+++ b/modules/resolve_conflictVEPFileName.nf
@@ -1,0 +1,45 @@
+/* Module to call moPepGen parseVEP */
+include { generate_args } from "${moduleDir}/common"
+
+process resolve_conflictVEPFileName {
+    publishDir params.final_output_dir,
+        mode: 'copy',
+        pattern: "*.gvf"
+
+    publishDir "${params.process_log_dir}/${task.process.replace(':', '/')}-${task.index}/",
+        mode: 'copy',
+        pattern: '.command.*',
+        saveAs: { "log${file(it).name}" }
+
+    input:
+        tuple(
+            val(identifier),
+            path(input_file)
+        )
+
+    output:
+        tuple(
+            val(identifier),
+            path(output_file)
+        )
+        path ".command.*"
+
+    script:
+    def filename = input_file.name
+    def tokens = filename.tokenize('.')
+    def basename
+    def suffix
+    if (tokens[-1] == 'gz') {
+        basename = tokens[0..-3].join('.')
+        suffix = tokens[-2..-1].join('.')
+    } else {
+        basename = tokens[0..-2].join('.')
+        suffix = tokens[-1]
+    }
+    output_file = "${basename}_${identifier}_${task.index}.${suffix}"
+    """
+    set -euo pipefail
+
+    ln -s ${input_file.toRealPath()} $output_file
+    """
+}


### PR DESCRIPTION
## Description

<!---
Briefly describe the changes included in this pull request and the paths to the test cases below. Ending with 'Closes #...' if appropriate
--->

### Closes #...

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] All test cases have passed.
