### PR TITLE
Update dependabot to group common submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "gitsubmodule" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # Group these two modules together for pull requests
+      # "pipeline-submodules" is an arbitrary name
+      pipeline-submodules:
+        patterns:
+          - "*/pipeline-Nextflow-config"
+          - "*/pipeline-Nextflow-module"


### PR DESCRIPTION
# Description
This updates the [dependabot](https://github.com/dependabot) configuration to group updates for pipeline-Nextflow-config and pipeline-Nextflow-module into a single PR. This repository is not using both of those submodules, so this won't have any major impact... but it will help to standardize these files across all of our pipelines.

See https://github.com/uclahs-cds/pipeline-recalibrate-BAM/pull/79 (and the resulting https://github.com/uclahs-cds/pipeline-recalibrate-BAM/pull/80) for an example of this configuration working.
