### PR TITLE
Version-pin Action versions from common repository

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy docs
-        uses: uclahs-cds/tool-Nextflow-action/build-and-deploy-docs@main
+        uses: uclahs-cds/tool-Nextflow-action/build-and-deploy-docs@v1


### PR DESCRIPTION
This repository is using a workflow or action from the [tool-Nextflow-action](https://github.com/uclahs-cds/tool-Nextflow-action) repository, but it is referencing the old `latest` tag or the `main` branch. This PR pins that reference to the newly-released [`v1` tag](https://github.com/uclahs-cds/tool-Nextflow-action/releases/tag/v1.0.0) - that way we'll be able to make breaking changes in that repository without impacting existing functionality.
